### PR TITLE
Hack for visualization & retro view iAPS pill device status & predictions

### DIFF
--- a/lib/plugins/openaps.js
+++ b/lib/plugins/openaps.js
@@ -478,9 +478,15 @@ function init (ctx) {
 
     if ('enacted' === prop.status.code) {
       var canceled = prop.lastEnacted.rate === 0 && prop.lastEnacted.duration === 0;
+      var bg = prop.lastEnacted.bg;
+        var units = sbx.data.profile.getUnits();
+
+        if (units === 'mmol') {
+          bg = Math.round(bg / consts.MMOL_TO_MGDL * 10) / 10;
+        }
 
       var valueParts = [
-        valueString('BG: ', prop.lastEnacted.bg)
+        valueString('BG: ', bg)
         , ', <b>Temp Basal' + (canceled ? ' Canceled' : ' Started') + '</b>'
         , canceled ? '' : ' ' + prop.lastEnacted.rate.toFixed(2) + ' for ' + prop.lastEnacted.duration + 'm'
         , valueString(', ', prop.lastEnacted.reason)

--- a/lib/plugins/openaps.js
+++ b/lib/plugins/openaps.js
@@ -399,14 +399,14 @@ function init (ctx) {
         }
 
         var valueParts = [
-          valueString('BG: ', bg)
-          , valueString(', ', prop.lastSuggested.reason)
-          , prop.lastSuggested.sensitivityRatio ? ', <b>Sensitivity Ratio:</b> ' + prop.lastSuggested.sensitivityRatio : ''
+          valueString('• <b>BG:</b> ', bg)
+          , valueString(' • ', prop.lastSuggested.reason)
+          , prop.lastSuggested.sensitivityRatio ? '• <b>Sensitivity Ratio:</b> ' + (parseFloat(prop.lastSuggested.sensitivityRatio) * 100).toFixed(0) + '%' : ''
         ];
 
-        if (_.includes(selectedFields, 'iob')) {
+        //if (_.includes(selectedFields, 'iob')) { //Daniel: Commented out to always add IOB info to suggested devicestatus
           valueParts = concatIOB(valueParts);
-        }
+        //}
 
         events.push({
           time: prop.lastSuggested.moment
@@ -418,7 +418,7 @@ function init (ctx) {
     function concatIOB (valueParts) {
       if (prop.lastIOB) {
         valueParts = valueParts.concat([
-          ', IOB: '
+          ' • <b>IOB:</b> '
           , sbx.roundInsulinForDisplayFormat(prop.lastIOB.iob) + 'U'
           , prop.lastIOB.basaliob ? ', Basal IOB ' + sbx.roundInsulinForDisplayFormat(prop.lastIOB.basaliob) + 'U' : ''
           , prop.lastIOB.bolusiob ? ', Bolus IOB ' + sbx.roundInsulinForDisplayFormat(prop.lastIOB.bolusiob) + 'U' : ''
@@ -476,7 +476,14 @@ function init (ctx) {
       return points;
     }
 
-    if ('enacted' === prop.status.code) {
+    // Daniel: This is the "hack" that makes iAPS pill and prediction chart update nearly 100% in Nightscout chart
+    // One downside is that the lastenacted valueparts only shows up in iAPS for the latest entry, and dont show up in iAPS pill in retro view, only the headline that iAPS was enacted, and then the valueparts from last.suggested. This is due to the 3 minutes offset, which i havent been able to resolve in this hack
+    // I've added IOB, IOB Basal and IOB Bolus info to suggested status, which makes the suggested info practically identical to enacted valuepart
+    // "suggested" needs to be uploaded from iAPS in conjunction woth "enacted" for retro info to show (some versions of iAPS just uploads enacted, please check this in your instnance and add suggested upload to iAPS)
+    // Sometimes, when uploads from iAPS comes in late, the prediction lines and iAPS pill can temporary disappar in real time view, but it should come back at the 3 min ago mark and also populate eventual missing data in the previous 5 min point to make history complete
+    // In my testing, all enacted/suggested statuses that actually gets uploaded from iAPS to NS->MongoDB is availible in 
+    // WHat do the hack do? It checks if the event is 'enacted' within the last 3 minutes, effectively widening the window for how old entries that gets visualized and saved in ddata in Nightscout (which makes them available in the openaps pill retroview)
+if ('enacted' === prop.status.code && prop.lastEnacted.moment.isAfter(moment().subtract(3, 'minutes'))) {
       var canceled = prop.lastEnacted.rate === 0 && prop.lastEnacted.duration === 0;
       var bg = prop.lastEnacted.bg;
         var units = sbx.data.profile.getUnits();
@@ -486,18 +493,19 @@ function init (ctx) {
         }
 
       var valueParts = [
-        valueString('BG: ', bg)
-        , ', <b>Temp Basal' + (canceled ? ' Canceled' : ' Started') + '</b>'
-        , canceled ? '' : ' ' + prop.lastEnacted.rate.toFixed(2) + ' for ' + prop.lastEnacted.duration + 'm'
+        valueString('• <b>BG:</b> ', bg)
+        , '• <b>Temp Basal' + (canceled ? ' Canceled' : ' Started') + '</b>'
+        , canceled ? '' : ' ' + prop.lastEnacted.rate.toFixed(2) + 'U/h for ' + prop.lastEnacted.duration + 'm'
         , valueString(', ', prop.lastEnacted.reason)
-        , prop.lastEnacted.mealAssist && _.includes(selectedFields, 'meal-assist') ? ' <b>Meal Assist:</b> ' + prop.lastEnacted.mealAssist : ''
+        , prop.lastEnacted.mealAssist && _.includes(selectedFields, 'meal-assist') ? '• <b>Meal Assist:</b> ' + prop.lastEnacted.mealAssist : ''
       ];
 
-      if (prop.lastSuggested && prop.lastSuggested.moment.isAfter(prop.lastEnacted.moment)) {
-        addSuggestion();
-      } else {
-        valueParts = concatIOB(valueParts);
-      }
+      //Always add bot addsuggestion and valueparts in enacted info
+  if (prop.lastSuggested && prop.lastSuggested.moment.isAfter(prop.lastEnacted.moment)) {
+    addSuggestion();
+  }
+  
+  valueParts = concatIOB(valueParts);
 
       events.push({
         time: prop.lastEnacted.moment


### PR DESCRIPTION
 // Daniel: This is a "hack" that makes iAPS pill and prediction chart update nearly 100% in Nightscout chart
    // One downside is that the lastenacted valueparts only shows up in iAPS for the latest entry, and dont show up in iAPS pill in retro view, only the headline that iAPS was enacted, and then the valueparts from last.suggested. This is due to the 3 minutes offset, which i havent been able to resolve in this hack
    // I've added IOB, IOB Basal and IOB Bolus info to suggested status, which makes the suggested info practically identical to enacted valuepart
    // "suggested" needs to be uploaded from iAPS in conjunction woth "enacted" for retro info to show (some versions of iAPS just uploads enacted, please check this in your instnance and add suggested upload to iAPS)
    // Sometimes, when uploads from iAPS comes in late, the prediction lines and iAPS pill can temporary disappar in real time view, but it should come back at the 3 min ago mark and also populate eventual missing data in the previous 5 min point to make history complete
    // In my testing, all enacted/suggested statuses that actually gets uploaded from iAPS to NS->MongoDB is availible in 
    // WHat do the hack do? It checks if the event is 'enacted' within the last 3 minutes, effectively widening the window for how old entries that gets visualized and saved in ddata in Nightscout (which makes them available in the openaps pill retroview)